### PR TITLE
Fix bouncers where an interface included a method implemented by a class that was extended

### DIFF
--- a/src/main/java/net/minecraftforge/mappingverifier/InheratanceMap.java
+++ b/src/main/java/net/minecraftforge/mappingverifier/InheratanceMap.java
@@ -98,10 +98,12 @@ public class InheratanceMap {
                     Method target = cls.getMethod(m.bounce.name, m.bounce.desc);
                     if (target != null)
                         target.bouncers.add(m);
-                } else if (classes.containsKey(m.bounce.owner)) {
-                    addBouncer(classes.get(m.bounce.owner), m);
-                } else {
-                    bouncers.computeIfAbsent(m.bounce.owner, (name) -> new HashSet<>()).add(m);
+                } else if (cls.getParent() != null && cls.getParent().name.equals(m.bounce.owner)) {
+                    if (classes.containsKey(m.bounce.owner)) {
+                        addBouncer(classes.get(m.bounce.owner), m);
+                    } else {
+                        bouncers.computeIfAbsent(m.bounce.owner, (name) -> new HashSet<>()).add(m);
+                    }
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/mappingverifier/InheratanceMap.java
+++ b/src/main/java/net/minecraftforge/mappingverifier/InheratanceMap.java
@@ -91,7 +91,7 @@ public class InheratanceMap {
 
         for (MethodNode n : node.methods)
             cls.methods.put(n.name + n.desc, new Method(cls, n, lambdas.contains(node.name + '/' + n.name + n.desc)));
-        
+
         for (Method m : cls.methods.values()) {
             if (m.isBouncer()) {
                 if (cls.name.equals(m.bounce.owner)) {


### PR DESCRIPTION
Fixes the false positive caused by the `TamableAnimal` and `AbstractHorse` class where both implemented `OwnableEntity` which includes a method named `getLevel` that returns an `EntityGetter` along with both classes extending `Entity` which includes another method named `getLevel` but returning `Level` while also implementing the method in `OwnableEntity` for `TamableAnimal` and `AbstractHorse`.